### PR TITLE
fix: address Obsidian community bot feedback

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -615,7 +615,7 @@ export default class NotePlayerPlugin extends Plugin implements PlaylistViewHost
     return match?.path ?? fileName;
   }
 
-  private async getAvailablePlaylistPath(name: string): Promise<string> {
+  private getAvailablePlaylistPath(name: string): string {
     const baseName = sanitizeFileName(name);
     let attempt = normalizePath(`${this.settings.playlistFolder}/${baseName}.md`);
     let index = 2;

--- a/src/styles.css
+++ b/src/styles.css
@@ -639,3 +639,11 @@
 	gap: 8px;
 	padding: 10px 0;
 }
+
+.onp-hidden {
+	display: none;
+}
+
+.onp-setting-input-full {
+	width: 100%;
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -96,7 +96,7 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 
 		const getProperties = () => collectVaultProperties(this.app);
 
-		containerEl.createEl('h2', { text: 'Obsidian Note Player' });
+		new Setting(containerEl).setHeading().setName('Obsidian Note Player');
 
 		new Setting(containerEl)
 			.setName('Playlist folder')
@@ -110,10 +110,10 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 						await this.plugin.refresh();
 					});
-				text.inputEl.style.width = '100%';
+				text.inputEl.addClass('onp-setting-input-full');
 			});
 
-		containerEl.createEl('h3', { text: 'Music Note Mapping' });
+		new Setting(containerEl).setHeading().setName('Music Note Mapping');
 
 		new Setting(containerEl)
 			.setName('URL properties')
@@ -127,7 +127,7 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 						await this.plugin.refresh();
 					});
-				text.inputEl.style.width = '100%';
+				text.inputEl.addClass('onp-setting-input-full');
 				new CommaPropertySuggest(this.app, text.inputEl, getProperties);
 			});
 
@@ -143,7 +143,7 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 						await this.plugin.refresh();
 					});
-				text.inputEl.style.width = '100%';
+				text.inputEl.addClass('onp-setting-input-full');
 				new CommaPropertySuggest(this.app, text.inputEl, getProperties);
 			});
 
@@ -159,11 +159,11 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 						await this.plugin.refresh();
 					});
-				text.inputEl.style.width = '100%';
+				text.inputEl.addClass('onp-setting-input-full');
 				new CommaPropertySuggest(this.app, text.inputEl, getProperties);
 			});
 
-		containerEl.createEl('h3', { text: 'Playlist Note Schema' });
+		new Setting(containerEl).setHeading().setName('Playlist Note Schema');
 
 		new Setting(containerEl)
 			.setName('Track list property')
@@ -240,7 +240,7 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 				new PropertySuggest(this.app, text.inputEl, getProperties);
 			});
 
-		containerEl.createEl('h3', { text: 'Companion Bases' });
+		new Setting(containerEl).setHeading().setName('Companion Bases');
 		containerEl.createEl('p', {
 			text: 'The plugin can generate Music.base and Playlists.base beside your playlist folder. For music-note mapping lists, the first property becomes the Bases column.',
 			cls: 'setting-item-description',
@@ -257,7 +257,7 @@ export class NotePlayerSettingsTab extends PluginSettingTab {
 					}),
 			);
 
-		containerEl.createEl('h3', { text: 'Audio fallback' });
+		new Setting(containerEl).setHeading().setName('Audio fallback');
 		containerEl.createEl('p', {
 			text: 'When YouTube embed playback is unavailable, the plugin downloads audio via yt-dlp.',
 			cls: 'setting-item-description',

--- a/src/ui/views/NotePlayerView.ts
+++ b/src/ui/views/NotePlayerView.ts
@@ -252,7 +252,7 @@ export class NotePlayerView extends ItemView {
 
 		const current = state.currentTrack;
 		if (!current) {
-			elements.playerPanel.style.display = 'none';
+			elements.playerPanel.addClass('onp-hidden');
 			this.lastRenderedTrackPath = null;
 			elements.progressBar = null;
 			elements.progressFill = null;
@@ -269,7 +269,7 @@ export class NotePlayerView extends ItemView {
 		// Show install instructions when yt-dlp is not available
 		const audioCacheService = this.host.getAudioCacheService?.();
 		if (audioCacheService && !audioCacheService.isAvailable()) {
-			elements.playerPanel.style.display = '';
+			elements.playerPanel.removeClass('onp-hidden');
 			const installNotice = elements.playerPanel.createDiv({ cls: 'onp-download-overlay' });
 			installNotice.createDiv({ cls: 'onp-download-text', text: 'Install yt-dlp to play music' });
 			installNotice.createDiv({ cls: 'onp-download-text onp-install-hint', text: 'brew install yt-dlp' });
@@ -278,7 +278,7 @@ export class NotePlayerView extends ItemView {
 
 		const playbackState = state.playbackState;
 
-		elements.playerPanel.style.display = '';
+		elements.playerPanel.removeClass('onp-hidden');
 		const playerRail = elements.playerPanel.createDiv({ cls: 'onp-now-playing-shell' });
 		const summary = playerRail.createDiv({ cls: 'onp-now-playing-summary' });
 		const trackCard = summary.createDiv({ cls: 'onp-track-card onp-track-card--compact onp-player-track-card' });

--- a/src/ui/views/PlaylistNameModal.ts
+++ b/src/ui/views/PlaylistNameModal.ts
@@ -13,7 +13,7 @@ export class PlaylistNameModal extends Modal {
 	onOpen(): void {
 		const { contentEl } = this;
 		contentEl.empty();
-		contentEl.createEl('h3', { text: 'Create playlist' });
+		new Setting(contentEl).setHeading().setName('Create playlist');
 		contentEl.createEl('p', {
 			text: 'This creates a note-backed playlist note in your configured playlist folder.',
 		});

--- a/styles.css
+++ b/styles.css
@@ -639,3 +639,11 @@
 	gap: 8px;
 	padding: 10px 0;
 }
+
+.onp-hidden {
+	display: none;
+}
+
+.onp-setting-input-full {
+	width: 100%;
+}


### PR DESCRIPTION
## Summary

- Remove `async` from `getAvailablePlaylistPath` — method contains no `await`, flagged by bot as unnecessary async
- Replace `containerEl.createEl('h2'/'h3')` with `new Setting(containerEl).setHeading().setName(...)` in settings tab and modal
- Replace `text.inputEl.style.width = '100%'` with `text.inputEl.addClass('onp-setting-input-full')` + CSS class
- Replace `element.style.display = 'none'/'``'` with `addClass/removeClass('onp-hidden')` + CSS class

## Test plan

- [x] `pnpm run ci` passes (build + lint + 64 tests)
- [ ] Open settings tab — headings render correctly, text inputs fill full width
- [ ] Open player view — player panel hides/shows correctly when track is selected/deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)